### PR TITLE
Add note to README to keep src/art.js as is

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ For more information about Canvas, you can read its [documentation](https://deve
 }
 ```
 
+_Please keep `src/art.js` as it is._ If you follow step 10 above, a script will add your art automatically after your PR is merged.
+
 11. Pull from the upstream again, like we did in step 3. This is to ensure we still have the latest code.
 
     - `git pull upstream master`


### PR DESCRIPTION
@MattCSmith I've noticed that some people start modifying `src/art.js` directly.

I've added a note to step 10. Not sure if it helps or is not necessary.