### PR TITLE
exit from commit files step if no new art has been added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,15 @@ jobs:
 
       - name: Commit files
         run: |
+          NEWART=`git diff HEAD@{1} --stat -- ./src/art.js | wc -l`
+          if [[ $NEWART -le 0 ]];then
+            echo "no changes to src/art.js"
+            exit 0
+          fi
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git commit -m "Updated art.json" -a
+          git commit -m "Updated art.js card JSON" -a
+          
       
       - name: Push changes
         uses: ad-m/github-push-action@master


### PR DESCRIPTION
Our build process fails if there are no changes to the art.js file, git complains about an empty commit.
This logic should detect if _no changes_ have been made, and abort the commit step.

~Not sure how to actually test this without merging to master.
@MattCSmith  ?~

I have tested this on my fork, and it appears to work without error in both scenarios.